### PR TITLE
fix: prevent loading the script twice if already enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,9 +46,17 @@ const buildResetObjects = (props) => {
  */
 
 GTM.prototype.initialize = function () {
+  push({ userConsents: this.options.userConsents });
+
+  // prevents to load the script and track twice
+  // if already loaded (e.g: enabledByDefault)
+  if (this.loaded()) {
+    this.ready();
+    return;
+  }
+
   this.previousProps = {};
   push({ "gtm.start": Number(new Date()), event: "gtm.js" });
-  push({ userConsents: this.options.userConsents });
 
   if (this.options.environment.length) {
     this.load("with-env", this.options, this.ready);


### PR DESCRIPTION
This patch prevents a double script loading in the page along with a new GTM context when the integration is enabled by default on a website.